### PR TITLE
fix copy to clipboard race condition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,14 +46,21 @@ window.onload = function() {
         window.localStorage.setItem(seed, JSON.stringify(data));
     });
 
-    const shareJoinURL = (joinID: string) => {
+    const shareJoinURL = async (joinID: string) => {
         let url = location.protocol + '//' + location.host + location.pathname;
         let params = new URLSearchParams(window.location.search);
         params.set('joinID', joinID);
         params.delete('hostID');
         let joinURL = url + '?' + params.toString();
-        navigator.clipboard.writeText(joinURL);
-        alert('Attempted to copy join link to clipboard:\n' + joinURL);
+        try {
+            await navigator.clipboard.writeText(joinURL);
+            alert('Join link copied to clipboard!');
+        } catch (e) {
+            // TODO: display some UI with the link so it can be copied manually. text can't be
+            // copied from alerts.
+            alert('Failed to copy join link to clipboard. Check the console for more details.');
+            console.info(`Join link: ${joinURL}`);
+        }
     }
 
     const startGame = () => {


### PR DESCRIPTION
I believe since copying is an async action, triggering the alert could cause a race condition where the copy fails because the alert has taken focus out of the window (#3 ). I've also modified the failure case to log the entire URL to the console so it can be more easily copied. I'd recommend adding the link in the DOM somewhere so it can be copied directly by someone who doesn't know how to open the console.